### PR TITLE
WEBDEV-9575: Fix RabbitMQ data persistence

### DIFF
--- a/harnesses.json
+++ b/harnesses.json
@@ -9,6 +9,11 @@
       "type": "tar.gz",
       "url": "https://github.com/teufelaudio/harness-spryker/archive/1.6.0.tar.gz",
       "date": "2024-12-05"
+    },
+    "v1.6.1": {
+      "type": "tar.gz",
+      "url": "https://github.com/teufelaudio/harness-spryker/archive/refs/heads/fix/WEBDEV-9575-fix-rabbitmq-data-persistence.tar.gz",
+      "date": "2024-12-31"
     }
   }
 }

--- a/harnesses.json
+++ b/harnesses.json
@@ -12,7 +12,7 @@
     },
     "v1.6.1": {
       "type": "tar.gz",
-      "url": "https://github.com/teufelaudio/harness-spryker/archive/refs/heads/fix/WEBDEV-9575-fix-rabbitmq-data-persistence.tar.gz",
+      "url": "https://github.com/teufelaudio/harness-spryker/archive/1.6.1.tar.gz",
       "date": "2024-12-31"
     }
   }

--- a/helm/app/templates/service/rabbitmq/deployment.yaml
+++ b/helm/app/templates/service/rabbitmq/deployment.yaml
@@ -11,6 +11,8 @@ metadata:
     app.kubernetes.io/component: rabbitmq
     app.service: {{ $.Values.resourcePrefix }}rabbitmq
 spec:
+  # Set fixed hostname. Reference: https://github.com/docker-library/rabbitmq/issues/106
+  hostname: rabbitmq
   replicas: 1
   selector:
     matchLabels:

--- a/helm/app/templates/service/rabbitmq/deployment.yaml
+++ b/helm/app/templates/service/rabbitmq/deployment.yaml
@@ -11,8 +11,6 @@ metadata:
     app.kubernetes.io/component: rabbitmq
     app.service: {{ $.Values.resourcePrefix }}rabbitmq
 spec:
-  # Set fixed hostname. Reference: https://github.com/docker-library/rabbitmq/issues/106
-  hostname: rabbitmq
   replicas: 1
   selector:
     matchLabels:
@@ -28,6 +26,8 @@ spec:
         app.kubernetes.io/component: rabbitmq
         app.service: {{ $.Values.resourcePrefix }}rabbitmq
     spec:
+      # Set fixed hostname. Reference: https://github.com/docker-library/rabbitmq/issues/106
+      hostname: rabbitmq
       containers:
       - env:
         {{- range $key, $value := (mergeOverwrite (dict) .environment .environment_dynamic) }}


### PR DESCRIPTION
## 🤔 Background

We do have a persistent volume for RabbitMQ service. This volume is mounted at `/var/lib/rabbitmq` which is the default data directory base path. However, it seems like RabbitMQ creates subdirectory under it using the hostname, and stores the data there. For example `/var/lib/rabbitmq/mnesia/rabbit@rabbitmq-84d84b67b8-lxn9r`.
The hostname changes every time a service is restarted. So, even tho the base path is part of the persistent volume, it still can not find the queue data after restart.
I found following message in RabbitMQ log in QA:
```
Node database directory at /var/lib/rabbitmq/mnesia/rabbit@rabbitmq-84d84b67b8-lxn9r is empty. Assuming we need to join an existing cluster or initialise from scratch...
```

## 💡 Goal

Fix RabbitMQ data persistence issue for K8S environments.

## 🔖 Changes

- Set a fixed hostname for RabbitMQ service, so that it does not change after restart and can always find the data directory