### PR TITLE
Fix help message

### DIFF
--- a/harness/config/teufel-commands.yml
+++ b/harness/config/teufel-commands.yml
@@ -152,5 +152,5 @@ command('docker login'):
 
 command('help'):
   exec: |
-    #!bash(workspace:/)|@
-    cat tools/workspace/help.txt
+    #!bash(harness:/)|@
+    cat help.txt


### PR DESCRIPTION
As we moved the help.txt file to the internal harness, we also need to modify the command to use the new location.