### PR TITLE
Make RabbitMQ Configurable

### DIFF
--- a/.ci/.gitignore
+++ b/.ci/.gitignore
@@ -1,0 +1,1 @@
+tmp-test

--- a/.ci/sample-dynamic/harnesses.json
+++ b/.ci/sample-dynamic/harnesses.json
@@ -1,0 +1,6 @@
+{
+  "inviqa/spryker": {
+    "vx.x.x": {
+    }
+  }
+}

--- a/.ci/sample-dynamic/workspace.yml
+++ b/.ci/sample-dynamic/workspace.yml
@@ -2,6 +2,8 @@ workspace('ci-spryker-sample-dynamic'):
   description: generated local workspace for ci-spryker-sample.
   harness: inviqa/spryker
 
+harness.repository.source('name'): ./harnesses.json
+
 attribute('aws.bucket'): null
 attribute('app.repository'): null
 attribute('aws.access_key_id'): null

--- a/.ci/sample-static/harnesses.json
+++ b/.ci/sample-static/harnesses.json
@@ -1,0 +1,6 @@
+{
+  "inviqa/spryker": {
+    "vx.x.x": {
+    }
+  }
+}

--- a/.ci/sample-static/workspace.yml
+++ b/.ci/sample-static/workspace.yml
@@ -2,12 +2,11 @@ workspace('ci-spryker-sample-static'):
   description: generated local workspace for ci-spryker-sample.
   harness: inviqa/spryker
 
+harness.repository.source('name'): ./harnesses.json
+
 attribute('app.build'): static
 
 attribute('aws.bucket'): null
 attribute('app.repository'): null
 attribute('aws.access_key_id'): null
 attribute('aws.secret_access_key'): null
-
-attribute('spryker.oauth_client_secret'): '= decrypt("YTozOntpOjA7czo3OiJkZWZhdWx0IjtpOjE7czoyNDoi/ZxjAtTonBTdHCfPRmh3rlDOOTPZ8oaVIjtpOjI7czo2NDoiXHkN92FXiuuj/PVZKwzJEKtsQzRtAEvdPSYT/6mEA2GVtk+98N4ch+y+MVbg6REiwTAFXOZSb7lEyqZOJMEY+iI7fQ==")'
-attribute('spryker.zed_request_token'): '= decrypt("YTozOntpOjA7czo3OiJkZWZhdWx0IjtpOjE7czoyNDoi5TNpTpnAi3Yjlstw46A63Pvn1nnGoE1VIjtpOjI7czo5NjoiFHj6M4K5I2pUBD5t2nnjzhR6jixzGOtQl/HSBWWyrD9TFmg+Qw82CLZlqBYgQXaCDiOB1GV9tVKAuvvr9ntHZ0KWeZLu5spfhdaqcVsJVm2kxNX6A1YKb5mw/g4V4NvAIjt9")'

--- a/.ci/test
+++ b/.ci/test
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+export path_test=".ci/tmp-test"
+
+function setup()
+(
+    local mode="$1"
+
+    if [ -d "${path_test}" ]; then
+        rm -rf "${path_test}"
+    fi
+
+    cp -ap ".ci/sample-${mode}" "${path_test}"
+    rsync --archive --exclude="**/.git" --exclude="**/.ci" ./ "${path_test}/.my127ws/"
+)
+
+function prepare_environment()
+(
+    cd "${path_test}"
+    ws harness prepare
+)
+
+function main()
+{
+    local mode="$1"
+
+    setup "$mode"
+    prepare_environment
+}
+
+main "$@"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ https://github.com/inviqa/k8s-project-cluster/blob/0.1.x-dev/docs/cluster-manage
 
 ## How to test?
 There are two modes of this harness: static (for CI environment) and dynamic (for local environment).
+Static mode is a fixed file system, and dynamic uses mutagen to sync file changes with the console and php-fpm containers.
+
 You can test both of them using below command:
 ```sh
 .ci/test static

--- a/README.md
+++ b/README.md
@@ -18,3 +18,12 @@ To generate and encrypt secrets for pipeline environments:
 https://github.com/inviqa/k8s-project-cluster/blob/0.1.x-dev/docs/cluster-management/sealed-secrets/README.md
 
 [Workspace]: https://github.com/my127/workspace
+
+## How to test?
+There are two modes of this harness: static (for CI environment) and dynamic (for local environment).
+You can test both of them using below command:
+```sh
+.ci/test static
+.ci/test dynamic
+```
+It will create a new directory at `.ci/tmp-test` that will compile the harness and find any twig compilation errors.

--- a/_twig/docker-compose.yml/service/rabbitmq.yml.twig
+++ b/_twig/docker-compose.yml/service/rabbitmq.yml.twig
@@ -15,3 +15,9 @@
       - traefik.port={{ @('rabbitmq.api_port') }}
       - co.elastic.logs/module=rabbitmq
       - co.elastic.metrics/module=rabbitmq
+    volumes:
+      - ./.my127ws/docker/image/rabbitmq/root/etc/rabbitmq/definitions.json:/etc/rabbitmq/definitions.json:ro
+      - ./.my127ws/docker/image/rabbitmq/root/etc/rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins:ro
+{% if @('app.build') != 'static' and @('rabbitmq.port_forward') is not empty %}
+    ports: {{ to_nice_yaml(@('rabbitmq.port_forward'), 2, 6) | raw }}
+{% endif %}

--- a/docker/image/rabbitmq/root/etc/rabbitmq/definitions.json.twig
+++ b/docker/image/rabbitmq/root/etc/rabbitmq/definitions.json.twig
@@ -1,0 +1,40 @@
+{% spaceless %}
+{% set vhosts = [] %}
+{% for vhost in @('rabbitmq.vhosts') %}
+  {% set vhosts = vhosts | merge([{"name": vhost,"metadata": {"description": "","tags": []}, "limits": []}]) %}
+{% endfor %}
+{% set users = [] %}
+{% set permissions = [] %}
+{% for user in @('rabbitmq.users') %}
+  {% set users = users | merge([{
+    "hashing_algorithm": "rabbit_password_hashing_sha256",
+    "limits": {},
+    "name": user.username,
+    "password_hash": user.password_hash,
+    "tags": user.tags
+  }]) %}
+  {% for permission in user.permissions %}
+    {% set permissions = permissions | merge([{
+      "configure": permission.configure,
+      "read": permission.read,
+      "user": user.username,
+      "vhost": permission.vhost,
+      "write": permission.write
+    }]) %}
+  {% endfor %}
+{% endfor %}
+{% endspaceless %}
+{
+  "bindings": [],
+  "exchanges": [],
+  "global_parameters": [],
+  "parameters": [],
+  "permissions": {{ permissions | json_encode(constant('JSON_UNESCAPED_SLASHES')) }},
+  "policies": [],
+  "queues": [],
+  "rabbit_version": "{{ @('rabbitmq.version') }}",
+  "rabbitmq_version": "{{ @('rabbitmq.version') }}",
+  "topic_permissions": [],
+  "users": {{ users | json_encode(constant('JSON_UNESCAPED_SLASHES')) }},
+  "vhosts": {{ vhosts | json_encode(constant('JSON_UNESCAPED_SLASHES')) }}
+}

--- a/docker/image/rabbitmq/root/etc/rabbitmq/definitions.json.twig
+++ b/docker/image/rabbitmq/root/etc/rabbitmq/definitions.json.twig
@@ -8,7 +8,6 @@
 {% for user in @('rabbitmq.users') %}
   {% set users = users | merge([{
     "hashing_algorithm": "rabbit_password_hashing_sha256",
-    "limits": {},
     "name": user.username,
     "password_hash": user.password_hash,
     "tags": user.tags

--- a/docker/image/rabbitmq/root/etc/rabbitmq/enabled_plugins
+++ b/docker/image/rabbitmq/root/etc/rabbitmq/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_management,rabbitmq_stream_management].

--- a/harness.yml
+++ b/harness.yml
@@ -103,7 +103,6 @@ attributes:
     password: spryker
     vhosts:
       default: '/'
-      product-document-service: 'product-document-service'
     port_forward: []
     users:
       - username: spryker

--- a/harness.yml
+++ b/harness.yml
@@ -102,10 +102,19 @@ attributes:
     user: spryker
     password: spryker
     vhosts:
-      default: 'de-spryker'
-      DE: = 'de-spryker'
-      AT: = 'at-spryker'
-      US: = 'us-spryker'
+      default: '/'
+      product-document-service: 'product-document-service'
+    port_forward: []
+    users:
+      - username: spryker
+        password_hash: yRrkqC5fk0FMKj8psg3CmwF8K0YhQL5x6bfRXBtfve+BIq3g
+        tags:
+          - administrator
+        permissions:
+          - vhost: '/'
+            configure: '.*'
+            write: '.*'
+            read: '.*'
   jenkins:
     host: jenkins
     port: 8080

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -395,7 +395,8 @@ attributes.default:
 
   rabbitmq:
     image: rabbitmq
-    tag: '3.8-management-alpine'
+    tag: '3.12-management-alpine'
+    version: '3.12.14'
     api_port: 15672
     erlang_cookie: TeTTiwT9y548yIcfw4peaOrqgtLItD6B
     external_host: = 'rabbitmq-' ~ @('hostname')

--- a/harness/attributes/docker-base.yml
+++ b/harness/attributes/docker-base.yml
@@ -140,14 +140,18 @@ attributes:
     rabbitmq:
       enabled: "= 'rabbitmq' in @('app.services')"
       image: = @('rabbitmq.image') ~ ':' ~ @('rabbitmq.tag')
+      version:
       environment:
         RABBITMQ_DEFAULT_USER: = @('rabbitmq.user')
         RABBITMQ_DEFAULT_VHOST: = @('rabbitmq.vhosts.default')
+        RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: "-rabbitmq_management load_definitions '/etc/rabbitmq/definitions.json'"
       environment_secrets:
         RABBITMQ_DEFAULT_PASS: = @('rabbitmq.password')
         RABBITMQ_ERLANG_COOKIE: = @('rabbitmq.erlang_cookie')
       resources:
         memory: "1024Mi"
+    chrome:
+      image: = 'yukinying/chrome-headless-browser-stable:125.0.6422.141'
     redis:
       image: redis:6-alpine
       options:

--- a/harness/config/confd.yml
+++ b/harness/config/confd.yml
@@ -21,6 +21,7 @@ confd('harness:/'):
   - { src: docker/image/elasticsearch/Dockerfile }
   - { src: docker/image/lighthouse/Dockerfile }
   - { src: docker/image/lighthouse/root/app/run.sh }
+  - { src: docker/image/rabbitmq/root/etc/rabbitmq/definitions.json }
   - { src: docker/image/nginx/Dockerfile }
   - { src: docker/image/nginx/root/docker-entrypoint.d/config_render.sh }
   - { src: docker/image/nginx/root/etc/nginx/conf.d/0-nginx.conf }

--- a/harnesses.json
+++ b/harnesses.json
@@ -32,7 +32,7 @@
     },
     "v1.6.5": {
       "type": "tar.gz",
-      "url": "https://github.com/teufelaudio/harness-spryker/archive/refs/heads/task/WEBDEV-9814-make-rabbitmq-configurable.tar.gz",
+      "url": "https://github.com/teufelaudio/harness-spryker/archive/1.6.5.tar.gz",
       "date": "2025-02-26"
     }
   }

--- a/harnesses.json
+++ b/harnesses.json
@@ -29,6 +29,11 @@
       "type": "tar.gz",
       "url": "https://github.com/teufelaudio/harness-spryker/archive/1.6.4.tar.gz",
       "date": "2025-02-17"
+    },
+    "v1.6.5": {
+      "type": "tar.gz",
+      "url": "https://github.com/teufelaudio/harness-spryker/archive/refs/heads/task/WEBDEV-9814-make-rabbitmq-configurable.tar.gz",
+      "date": "2025-02-26"
     }
   }
 }


### PR DESCRIPTION
Changes:
- Initialize RabbitMQ using definitions.json file to make it possible to change any configuration
- Build definitions.json using workspace attributes
- Make it possible to forward ports for RabbitMQ service
- Add test bash script to easily compile and test this harness locally