### PR TITLE
Fix rabbitmq helm deployment

### DIFF
--- a/harness/config/confd.yml
+++ b/harness/config/confd.yml
@@ -52,6 +52,7 @@ confd('harness:/'):
   - { src: mutagen.yml, dst: workspace:/mutagen.yml } # docker-compose.yml render reads this file
   - { src: docker-compose.yml, dst: workspace:/docker-compose.yml }
   - { src: harness/scripts/enable.sh }
+  - { src: helm/app/_twig/templates/service/rabbitmq/configmap.yaml, dst: harness:/helm/app/templates/service/rabbitmq/configmap.yaml }
   - { src: helm/app/_twig/templates/service/varnish/configmap.yaml, dst: harness:/helm/app/templates/service/varnish/configmap.yaml }
   - { src: helm/app/values.yaml }
   - { src: helm/app/values-production.yaml }

--- a/harnesses.json
+++ b/harnesses.json
@@ -32,7 +32,7 @@
     },
     "v1.6.5": {
       "type": "tar.gz",
-      "url": "https://github.com/teufelaudio/harness-spryker/archive/refs/heads/fix/MISC-fix-rabbitmq-helm-deployment.tar.gz",
+      "url": "https://github.com/teufelaudio/harness-spryker/archive/1.6.5.tar.gz",
       "date": "2025-03-03"
     }
   }

--- a/harnesses.json
+++ b/harnesses.json
@@ -32,8 +32,8 @@
     },
     "v1.6.5": {
       "type": "tar.gz",
-      "url": "https://github.com/teufelaudio/harness-spryker/archive/1.6.5.tar.gz",
-      "date": "2025-02-26"
+      "url": "https://github.com/teufelaudio/harness-spryker/archive/refs/heads/fix/MISC-fix-rabbitmq-helm-deployment.tar.gz",
+      "date": "2025-03-03"
     }
   }
 }

--- a/helm/app/_twig/templates/service/rabbitmq/configmap.yaml.twig
+++ b/helm/app/_twig/templates/service/rabbitmq/configmap.yaml.twig
@@ -14,7 +14,6 @@ data:
 {% endverbatim %}
 {{ indent(config, 4) }}
 {%- verbatim %}
-{{ end }}
   enabled_plugins: |
 {% endverbatim %}
 {{ indent(plugins, 4) }}

--- a/helm/app/_twig/templates/service/rabbitmq/configmap.yaml.twig
+++ b/helm/app/_twig/templates/service/rabbitmq/configmap.yaml.twig
@@ -1,0 +1,17 @@
+{% set blocks  = 'docker/image/rabbitmq/root/etc/rabbitmq/' %}
+{% verbatim %}
+{{ if .Values.services.rabbitmq.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $.Values.resourcePrefix }}rabbitmq-configuration
+  labels:
+    app.service: {{ $.Values.resourcePrefix }}rabbitmq
+data:
+  definitions.json: |
+{% endverbatim %}
+{%- set config = include(blocks ~ 'definitions.json.twig') %}
+{{ indent(config, 4) }}
+{%- verbatim %}
+{{ end }}
+{% endverbatim %}

--- a/helm/app/_twig/templates/service/rabbitmq/configmap.yaml.twig
+++ b/helm/app/_twig/templates/service/rabbitmq/configmap.yaml.twig
@@ -1,4 +1,6 @@
 {% set blocks  = 'docker/image/rabbitmq/root/etc/rabbitmq/' %}
+{%- set config = include(blocks ~ 'definitions.json.twig') %}
+{%- set plugins = include(blocks ~ 'enabled_plugins') %}
 {% verbatim %}
 {{ if .Values.services.rabbitmq.enabled }}
 apiVersion: v1
@@ -10,8 +12,12 @@ metadata:
 data:
   definitions.json: |
 {% endverbatim %}
-{%- set config = include(blocks ~ 'definitions.json.twig') %}
 {{ indent(config, 4) }}
+{%- verbatim %}
+{{ end }}
+  enabled_plugins: |
+{% endverbatim %}
+{{ indent(plugins, 4) }}
 {%- verbatim %}
 {{ end }}
 {% endverbatim %}

--- a/helm/app/templates/service/rabbitmq/deployment.yaml
+++ b/helm/app/templates/service/rabbitmq/deployment.yaml
@@ -61,6 +61,8 @@ spec:
         volumeMounts:
         - name: {{ $.Values.resourcePrefix }}rabbitmq-persistent-storage
           mountPath: /var/lib/rabbitmq
+        - name: {{ $.Values.resourcePrefix }}rabbitmq-configuration
+          mountPath: /etc/rabbitmq/
       restartPolicy: Always
       # Override to add the pull secret to fetch from the private docker.io repo
       imagePullSecrets:
@@ -73,6 +75,9 @@ spec:
 {{- else }}
         emptyDir: {}
 {{- end }}
+      - name: {{ $.Values.resourcePrefix }}rabbitmq-configuration
+        configMap:
+          name: {{ $.Values.resourcePrefix }}rabbitmq-configuration
 status: {}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### Background:
RabbitMQ service configuration is updated to use mounted configuration files in docker-compose. However, it does not work in kubernetes environment.

### Changes:
- Create config map for rabbitmq configuration files
- Mount this config map in rabbitmq deployment