### PR TITLE
Fix lighthouse commands

### DIFF
--- a/_twig/docker-compose.yml/service/lighthouse.yml.twig
+++ b/_twig/docker-compose.yml/service/lighthouse.yml.twig
@@ -3,7 +3,7 @@
     entrypoint: "/usr/bin/dumb-init --"
     command: "/bin/true"
     environment:
-      TARGET_URL: "{{ @('lighthouse.target.url') | raw }}"
+      TARGET_URL: "${TARGET_URL:-{{ @('lighthouse.target.url') | raw }}}"
       OUTPUT_RESULTS: "${OUTPUT_RESULTS:-}"
 {% if @('app.build') == 'dynamic' %}
     volumes:

--- a/_twig/docker-compose.yml/service/lighthouse.yml.twig
+++ b/_twig/docker-compose.yml/service/lighthouse.yml.twig
@@ -5,6 +5,7 @@
     environment:
       TARGET_URL: "${TARGET_URL:-{{ @('lighthouse.target.url') | raw }}}"
       OUTPUT_RESULTS: "${OUTPUT_RESULTS:-}"
+      DESKTOP: "${DESKTOP:-}"
 {% if @('app.build') == 'dynamic' %}
     volumes:
       - .my127ws/docker/image/lighthouse/root/app:/app

--- a/docker/image/lighthouse/root/app/run.sh.twig
+++ b/docker/image/lighthouse/root/app/run.sh.twig
@@ -6,10 +6,16 @@ set -o errexit
 
 TARGET_URL="${TARGET_URL:-${1:-}}"
 OUTPUT_RESULTS="${OUTPUT_RESULTS:-no}"
+PRESET=""
 
 if [ -z "$TARGET_URL" ] || ! [[ "$TARGET_URL" =~ https?:// ]]; then
   echo "Please provide a target URL to run lighthouse against" >&2
   exit 1
+fi
+
+if [ "$DESKTOP" == "yes" ]; then
+  echo "Running in desktop mode" >&2
+  PRESET="--preset=desktop"
 fi
 
 function output_results()
@@ -27,6 +33,7 @@ lighthouse --no-enable-error-reporting \
            --chrome-flags="--headless --no-sandbox=true --ignore-certificate-errors --disable-dev-shm-usage" \
            --output json \
            --output-path=/home/headless/lighthouse-results.json \
+           ${PRESET} \
            "${TARGET_URL}" >&2
 
 {% if @('lighthouse.success-thresholds.performance.enabled') %}

--- a/harness/config/teufel-commands.yml
+++ b/harness/config/teufel-commands.yml
@@ -120,8 +120,6 @@ command('lighthouse run-and-publish [<url>]'):
     TARGET_URL: = input.argument('url') ? input.argument('url'):@('lighthouse.target.url')
   exec: |
     #!bash(workspace:/)|@
-    ws lighthouse --with-results > data/lighthouse.json
-    docker cp data/lighthouse.json "$(docker ps --all --filter 'name=console' --format '{{.Names}}'):/app/data/lighthouse.json"
     passthru $COMPOSE_BIN exec -e TARGET_URL="$TARGET_URL" console vendor/bin/console lighthouse:result:publish
 
 command('run playwright'):

--- a/harness/config/teufel-commands.yml
+++ b/harness/config/teufel-commands.yml
@@ -122,7 +122,7 @@ command('lighthouse run-and-publish [<url>]'):
     #!bash(workspace:/)|@
     ws lighthouse --with-results > data/lighthouse.json
     docker cp data/lighthouse.json "$(docker ps --all --filter 'name=console' --format '{{.Names}}'):/app/data/lighthouse.json"
-    passthru $COMPOSE_BIN exec -e TARGET_URL=$TARGET_URL console vendor/bin/console lighthouse:result:publish
+    passthru $COMPOSE_BIN exec -e TARGET_URL="$TARGET_URL" console vendor/bin/console lighthouse:result:publish
 
 command('run playwright'):
   env:

--- a/harness/config/teufel-commands.yml
+++ b/harness/config/teufel-commands.yml
@@ -113,23 +113,16 @@ command('feature pipeline xdebug cli (on|off)'):
     docker cp .my127ws/docker/image/console/root/usr/local/etc/php/conf.d "$(docker ps --all --filter 'name=console' --format '{{.Names}}'):/usr/local/etc/php/"
     echo 'Done'
 
-# overwritten core harness command to disable TTY, so that we can forward only stdout (lighthouse result json) to a file
-command('lighthouse --with-results'):
+command('lighthouse run-and-publish [<url>]'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
-    OUTPUT_RESULTS:       = input.option('with-results') ? 'yes':'no'
-  exec: |
-    #!bash(workspace:/)|@
-    docker-compose run -T --rm lighthouse bash -i /app/run.sh
-
-command('lighthouse run-and-publish'):
-  env:
-    COMPOSE_PROJECT_NAME: = @('namespace')
+    COMPOSE_BIN: = @('docker.compose.bin')
+    TARGET_URL: = input.argument('url') ? input.argument('url'):@('lighthouse.target.url')
   exec: |
     #!bash(workspace:/)|@
     ws lighthouse --with-results > data/lighthouse.json
     docker cp data/lighthouse.json "$(docker ps --all --filter 'name=console' --format '{{.Names}}'):/app/data/lighthouse.json"
-    passthru ws exec vendor/bin/console lighthouse:result:publish
+    passthru $COMPOSE_BIN exec -e TARGET_URL=$TARGET_URL console vendor/bin/console lighthouse:result:publish
 
 command('run playwright'):
   env:

--- a/harness/config/teufel-commands.yml
+++ b/harness/config/teufel-commands.yml
@@ -113,17 +113,18 @@ command('feature pipeline xdebug cli (on|off)'):
     docker cp .my127ws/docker/image/console/root/usr/local/etc/php/conf.d "$(docker ps --all --filter 'name=console' --format '{{.Names}}'):/usr/local/etc/php/"
     echo 'Done'
 
-command('lighthouse run-and-publish [<url>]'):
+command('lighthouse run-and-publish [<url>] [--desktop]'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
     COMPOSE_BIN: = @('docker.compose.bin')
     TARGET_URL: = input.argument('url') ? input.argument('url'):@('lighthouse.target.url')
+    DESKTOP: = boolToString(input.option('desktop'))
   exec: |
     #!bash(workspace:/)|@
     passthru $COMPOSE_BIN build lighthouse
     ws lighthouse --with-results > data/lighthouse.json
     docker cp data/lighthouse.json "$(docker ps --all --filter 'name=console' --format '{{.Names}}'):/app/data/lighthouse.json"
-    passthru $COMPOSE_BIN exec -e TARGET_URL="$TARGET_URL" console vendor/bin/console lighthouse:result:publish
+    passthru $COMPOSE_BIN exec -e TARGET_URL=$TARGET_URL -e DESKTOP=$DESKTOP console vendor/bin/console lighthouse:result:publish
 
 command('run playwright'):
   env:

--- a/harness/config/teufel-commands.yml
+++ b/harness/config/teufel-commands.yml
@@ -120,6 +120,8 @@ command('lighthouse run-and-publish [<url>]'):
     TARGET_URL: = input.argument('url') ? input.argument('url'):@('lighthouse.target.url')
   exec: |
     #!bash(workspace:/)|@
+    ws lighthouse --with-results > data/lighthouse.json
+    docker cp data/lighthouse.json "$(docker ps --all --filter 'name=console' --format '{{.Names}}'):/app/data/lighthouse.json"
     passthru $COMPOSE_BIN exec -e TARGET_URL="$TARGET_URL" console vendor/bin/console lighthouse:result:publish
 
 command('run playwright'):

--- a/harness/config/teufel-commands.yml
+++ b/harness/config/teufel-commands.yml
@@ -120,6 +120,7 @@ command('lighthouse run-and-publish [<url>]'):
     TARGET_URL: = input.argument('url') ? input.argument('url'):@('lighthouse.target.url')
   exec: |
     #!bash(workspace:/)|@
+    passthru $COMPOSE_BIN build lighthouse
     ws lighthouse --with-results > data/lighthouse.json
     docker cp data/lighthouse.json "$(docker ps --all --filter 'name=console' --format '{{.Names}}'):/app/data/lighthouse.json"
     passthru $COMPOSE_BIN exec -e TARGET_URL="$TARGET_URL" console vendor/bin/console lighthouse:result:publish

--- a/harnesses.json
+++ b/harnesses.json
@@ -47,8 +47,8 @@
     },
     "v1.6.8": {
       "type": "tar.gz",
-      "url": "https://github.com/teufelaudio/harness-spryker/archive/refs/heads/task/fix-lighthouse-commands.tar.gz",
-      "date": "2025-06-24"
+      "url": "https://github.com/teufelaudio/harness-spryker/archive/1.6.8.tar.gz",
+      "date": "2025-06-27"
     }
   }
 }

--- a/harnesses.json
+++ b/harnesses.json
@@ -44,6 +44,11 @@
       "type": "tar.gz",
       "url": "https://github.com/teufelaudio/harness-spryker/archive/1.6.7.tar.gz",
       "date": "2025-04-03"
+    },
+    "v1.6.8": {
+      "type": "tar.gz",
+      "url": "https://github.com/teufelaudio/harness-spryker/archive/refs/heads/task/fix-lighthouse-commands.tar.gz",
+      "date": "2025-06-24"
     }
   }
 }


### PR DESCRIPTION
Changes:
- Allow overwriting TARGET_URL variable at run time for lighthouse service
- Fix lighthouse run and publish command to pass TARGET_URL variable to console container
- Remove duplicate "lighthouse --with-results" command (it is set in commands.yml too, and it is being parsed from there only)