### PR TITLE
Escape docker compose environment variables

### DIFF
--- a/_twig/docker-compose.yml/service/blackfire.yml.twig
+++ b/_twig/docker-compose.yml/service/blackfire.yml.twig
@@ -3,10 +3,10 @@
     labels:
       # deprecated, a later workspace release will disable by default
       - traefik.enable=false
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.blackfire.environment'),
         @('services.blackfire.environment_dynamic'),
         @('services.blackfire.environment_secrets')
-      ]), 2, 6) | raw }}
+      ])), 2, 6) | raw }}
     networks:
       - private

--- a/_twig/docker-compose.yml/service/console.yml.twig
+++ b/_twig/docker-compose.yml/service/console.yml.twig
@@ -22,13 +22,13 @@
 {% endif %}
     labels:
       - traefik.enable=false
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.php-base.environment'),
         @('services.php-base.environment_dynamic'),
         @('services.console.environment'),
         @('services.console.environment_dynamic'),
         @('services.php-base.environment_secrets'),
         @('services.console.environment_secrets')
-      ]), 2, 6) | raw }}
+      ])), 2, 6) | raw }}
     networks:
       - private

--- a/_twig/docker-compose.yml/service/cron.yml.twig
+++ b/_twig/docker-compose.yml/service/cron.yml.twig
@@ -9,14 +9,14 @@
 {% else %}
     image: {{ @('services.cron.image') }}
 {% endif %}
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.php-base.environment'),
         @('services.php-base.environment_dynamic'),
         @('services.cron.environment'),
         @('services.cron.environment_dynamic'),
         @('services.php-base.environment_secrets'),
         @('services.cron.environment_secrets')
-      ]), 2, 6) | raw }}
+      ])), 2, 6) | raw }}
     networks:
       - private
     labels:

--- a/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
+++ b/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
@@ -14,14 +14,14 @@
     depends_on:
       - console
       - jenkins
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.php-base.environment'),
         @('services.php-base.environment_dynamic'),
         @('services.jenkins-runner.environment'),
         @('services.jenkins-runner.environment_dynamic'),
         @('services.php-base.environment_secrets'),
         @('services.jenkins-runner.environment_secrets')
-      ]), 2, 6) | raw }}
+      ])), 2, 6) | raw }}
     networks:
       - private
     labels:

--- a/_twig/docker-compose.yml/service/jenkins.yml.twig
+++ b/_twig/docker-compose.yml/service/jenkins.yml.twig
@@ -1,9 +1,9 @@
   jenkins:
     image: {{ @('services.jenkins.image') }}
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
       @('services.jenkins.environment'),
       @('services.jenkins.environment_dynamic'),
-    ]), 2, 6) | raw }}
+    ])), 2, 6) | raw }}
     networks:
       - private
       - shared

--- a/_twig/docker-compose.yml/service/mongodb.yml.twig
+++ b/_twig/docker-compose.yml/service/mongodb.yml.twig
@@ -1,10 +1,10 @@
   mongodb:
     image: {{ @('services.mongodb.image') }}
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.mongodb.environment'),
         @('services.mongodb.environment_dynamic'),
         @('services.mongodb.environment_secrets')
-      ]), 2, 6) | raw }}
+      ])), 2, 6) | raw }}
     labels:
       # deprecated, a later workspace release will disable by default
       - traefik.enable=false

--- a/_twig/docker-compose.yml/service/mysql.yml.twig
+++ b/_twig/docker-compose.yml/service/mysql.yml.twig
@@ -8,11 +8,11 @@
       # deprecated, a later workspace release will disable by default
       - traefik.enable=false
     command: {{ to_nice_yaml(command, 2, 6) }}
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.mysql.environment'),
         @('services.mysql.environment_dynamic'),
         @('services.mysql.environment_secrets')
-      ]), 2, 6) | raw }}
+      ])), 2, 6) | raw }}
     networks:
       - private
 {% if @('app.build') != 'static' and @('docker.port_forward.enabled') %}

--- a/_twig/docker-compose.yml/service/nginx.yml.twig
+++ b/_twig/docker-compose.yml/service/nginx.yml.twig
@@ -23,11 +23,11 @@
       - traefik.docker.network=my127ws
       - traefik.port=80
 {% endif %}
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.nginx.environment'),
         @('services.nginx.environment_dynamic'),
         @('services.nginx.environment_secrets')
-      ]), 2, 6) | raw }}
+      ])), 2, 6) | raw }}
     links:
       - php-fpm:php-fpm
     networks:

--- a/_twig/docker-compose.yml/service/php-fpm-exporter.yml.twig
+++ b/_twig/docker-compose.yml/service/php-fpm-exporter.yml.twig
@@ -1,10 +1,10 @@
   php-fpm-exporter:
     image: {{ @('services.php-fpm-exporter.image') }}
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.php-fpm-exporter.environment'),
         @('services.php-fpm-exporter.environment_dynamic'),
         @('services.php-fpm-exporter.environment_secrets')
-      ]), 2, 6) | raw }}
+      ])), 2, 6) | raw }}
     labels:
       # deprecated, a later workspace release will disable by default
       - traefik.enable=false

--- a/_twig/docker-compose.yml/service/php-fpm.yml.twig
+++ b/_twig/docker-compose.yml/service/php-fpm.yml.twig
@@ -20,14 +20,14 @@
       - traefik.enable=false
     networks:
       - private
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.php-base.environment'),
         @('services.php-base.environment_dynamic'),
         @('services.php-fpm.environment'),
         @('services.php-fpm.environment_dynamic'),
         @('services.php-base.environment_secrets'),
         @('services.php-fpm.environment_secrets')
-      ]), 2, 6) | raw }}
+      ])), 2, 6) | raw }}
     expose:
 {% for pool in @('php-fpm.pools') %}
       - {{ pool.port }}

--- a/_twig/docker-compose.yml/service/postgres.yml.twig
+++ b/_twig/docker-compose.yml/service/postgres.yml.twig
@@ -4,11 +4,11 @@
       - traefik.enable=false
     volumes:
       - ./.my127ws/docker/image/postgres/root/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.postgres.environment'),
         @('services.postgres.environment_dynamic'),
         @('services.postgres.environment_secrets')
-      ]), 2, 6) | raw }}
+      ])), 2, 6) | raw }}
     networks:
       - private
 {% if @('app.build') != 'static' and @('docker.port_forward.enabled') %}

--- a/_twig/docker-compose.yml/service/rabbitmq.yml.twig
+++ b/_twig/docker-compose.yml/service/rabbitmq.yml.twig
@@ -1,10 +1,10 @@
   rabbitmq:
     image: {{ @('services.rabbitmq.image') }}
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.rabbitmq.environment'),
         @('services.rabbitmq.environment_dynamic'),
         @('services.rabbitmq.environment_secrets')
-      ]), 2, 6) | raw }}
+      ])), 2, 6) | raw }}
     networks:
       - private
       - shared

--- a/_twig/docker-compose.yml/service/solr.yml.twig
+++ b/_twig/docker-compose.yml/service/solr.yml.twig
@@ -5,11 +5,11 @@
 {% if @('app.build') == 'static' %}
     image: {{ @('services.solr.image') }}
 {% endif %}
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.solr.environment'),
         @('services.solr.environment_dynamic'),
         @('services.solr.environment_secrets')
-      ]), 2, 6) | raw }}
+      ])), 2, 6) | raw }}
     labels:
       - traefik.backend=solr-{{ @('workspace.name') }}
       - traefik.frontend.rule=Host:solr-{{ @('hostname') }}

--- a/_twig/docker-compose.yml/service/tideways.yml.twig
+++ b/_twig/docker-compose.yml/service/tideways.yml.twig
@@ -3,10 +3,10 @@
     labels:
       # deprecated, a later workspace release will disable by default
       - traefik.enable=false
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.tideways.environment'),
         @('services.tideways.environment_dynamic'),
         @('services.tideways.environment_secrets')
-      ]), 2, 6) | raw }}
+      ])), 2, 6) | raw }}
     networks:
       - private

--- a/_twig/docker-compose.yml/service/varnish.yml.twig
+++ b/_twig/docker-compose.yml/service/varnish.yml.twig
@@ -15,11 +15,11 @@
       # - traefik.docker.network=my127ws
       - traefik.http.routers.{{ @('workspace.name') }}-varnish.rule={{ traefikRules | join(' || ') }}
       - traefik.http.services.{{ @('workspace.name') }}-varnish.loadbalancer.server.port=80
-    environment: {{ to_nice_yaml(deep_merge([
+    environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
       @('services.varnish.environment'),
       @('services.varnish.environment_dynamic'),
       @('services.varnish.environment_secrets')
-      ]), 2, 6) | raw }}
+      ])), 2, 6) | raw }}
     links:
       - nginx:nginx
     volumes:

--- a/harness/config/teufel-functions.yml
+++ b/harness/config/teufel-functions.yml
@@ -26,3 +26,12 @@ function('join', [separator, array]): |
 function('get_env', [key]): |
   #!php
   = getenv($key);
+
+function('docker_compose_escape', [array]): |
+  #!php
+  foreach ($array as &$value) {
+    if (is_string($value)) {
+      $value = str_replace('$', '$$', $value);
+    }
+  }
+  = $array;

--- a/harnesses.json
+++ b/harnesses.json
@@ -49,6 +49,11 @@
       "type": "tar.gz",
       "url": "https://github.com/teufelaudio/harness-spryker/archive/1.6.8.tar.gz",
       "date": "2025-06-27"
+    },
+    "v1.6.9": {
+      "type": "tar.gz",
+      "url": "https://github.com/teufelaudio/harness-spryker/archive/refs/heads/task/escape-docker-composer-vars.tar.gz",
+      "date": "2025-07-17"
     }
   }
 }

--- a/harnesses.json
+++ b/harnesses.json
@@ -52,8 +52,8 @@
     },
     "v1.6.9": {
       "type": "tar.gz",
-      "url": "https://github.com/teufelaudio/harness-spryker/archive/refs/heads/task/escape-docker-composer-vars.tar.gz",
-      "date": "2025-07-17"
+      "url": "https://github.com/teufelaudio/harness-spryker/archive/1.6.9.tar.gz",
+      "date": "2025-07-18"
     }
   }
 }


### PR DESCRIPTION
Docker compose file does not like dollars. If you have a value with a dollar sign, you need to escape it with double dollars. Otherwise, it would try and do variable interpolation.