### PR TITLE
WEBDEV-10738: Add valkey service and enable it by default

### DIFF
--- a/_twig/docker-compose.yml/service/valkey.yml.twig
+++ b/_twig/docker-compose.yml/service/valkey.yml.twig
@@ -1,0 +1,12 @@
+  valkey:
+    image: {{ @('services.valkey.image')  }}
+    # evict any least recently used key even if they don't have a TTL
+    command: valkey-server --maxmemory {{ @('services.valkey.max_memory') }} --maxmemory-policy allkeys-lru --save 3600 1 --save 300 100 --save 60 10000
+    labels:
+      - traefik.enable=false
+    networks:
+      - private
+{% if @('app.build') != 'static' and @('docker.port_forward.enabled') %}
+    ports:
+      - "127.0.0.1:0:6379"
+{% endif %}

--- a/harness.yml
+++ b/harness.yml
@@ -17,7 +17,7 @@ attributes:
     services:
       - chrome
       - postgres
-      - redis
+      - valkey
       - elasticsearch
       - rabbitmq
       - jenkins
@@ -96,8 +96,11 @@ attributes:
   lighthouse:
     target:
       url: = 'https://' ~ @('yves.external_hosts.DE')
+  valkey:
+    protocol: tcp
   redis:
-    protocol: redis
+    protocol: "= @('services.valkey.enabled') ? @('valkey.protocol') : 'redis'"
+    host: "= @('services.valkey.enabled') ? @('valkey.host') : 'redis'"
   rabbitmq:
     user: spryker
     password: spryker
@@ -218,6 +221,8 @@ attributes:
         #hostPath: "..." alternatively for single node testing
         size: 1Gi
     redis:
+      enabled: true
+    valkey:
       enabled: true
     jenkins:
       enabled: true

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -415,6 +415,10 @@ attributes.default:
     host: redis-session
     port: 6379
 
+  valkey:
+    host: valkey
+    port: 6379
+
   smtp:
     host: 'mailhog-relay'
     port: 1025
@@ -458,6 +462,10 @@ attributes.default:
       size: 2Gi
     redis-session:
       enabled: true
+      accessMode: ReadWriteOnce
+      size: 2Gi
+    valkey:
+      enabled: false
       accessMode: ReadWriteOnce
       size: 2Gi
     solr:

--- a/harness/attributes/docker-base.yml
+++ b/harness/attributes/docker-base.yml
@@ -161,6 +161,7 @@ attributes:
     chrome:
       image: = 'yukinying/chrome-headless-browser-stable:125.0.6422.141'
     redis:
+      enabled: "= 'redis' in @('app.services')"
       image: redis:6-alpine
       options:
         # Handle many smaller keys
@@ -178,6 +179,7 @@ attributes:
         # 1.5 * maxmemory to allow copy on write snapshots
         memory: "1.5Gi"
     redis-session:
+      enabled: "= 'redis-session' in @('app.services')"
       image: redis:6-alpine
       options:
         # Handle many smaller keys
@@ -191,6 +193,13 @@ attributes:
           - 3600 1
           - 300 100
           - 60 10000
+      resources:
+        # 1.5 * maxmemory to allow copy on write snapshots
+        memory: "1.5Gi"
+    valkey:
+      enabled: "= 'valkey' in @('app.services')"
+      image: valkey/valkey:9-alpine
+      max_memory: 1GB
       resources:
         # 1.5 * maxmemory to allow copy on write snapshots
         memory: "1.5Gi"


### PR DESCRIPTION
Changes
- Add valkey service
- Enable it as default key-value storage service, replacing Redis