### PR TITLE
Add bitwarden secret manager service

### DIFF
--- a/.ci/sample-dynamic/workspace.yml
+++ b/.ci/sample-dynamic/workspace.yml
@@ -10,3 +10,6 @@ attribute('aws.access_key_id'): null
 attribute('aws.secret_access_key'): null
 
 attribute('docker.port_forward.enabled'): false
+
+attribute('services.bitwarden.enabled'): true
+attribute('bitwarden.project_id'): 1

--- a/.ci/sample-static/workspace.yml
+++ b/.ci/sample-static/workspace.yml
@@ -10,3 +10,6 @@ attribute('aws.bucket'): null
 attribute('app.repository'): null
 attribute('aws.access_key_id'): null
 attribute('aws.secret_access_key'): null
+
+attribute('services.bitwarden.enabled'): true
+attribute('bitwarden.project_id'): 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Install required tools
         run: |
-          apt-get update
-          apt-get install -y rsync
+          sudo apt-get update
+          sudo apt-get install -y rsync
           
           # Download the ws binary from the workspace releases
           curl -L https://github.com/my127/workspace/releases/download/0.4.1/ws -o /tmp/ws

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,15 +66,19 @@ jobs:
       - name: Test helm charts
         if: always()
         run: |
-          cd .ci/tmp-test/.my127ws/helm/preview
-          helm dependency build
-          helm template . > /dev/null
-          echo "Preview env helm chart is valid"
+          (
+            cd .ci/tmp-test/.my127ws/helm/preview
+            helm dependency build
+            helm template . > /dev/null
+            echo "Preview env helm chart is valid"
+          )
           
-          cd .ci/tmp-test/.my127ws/helm/qa
-          helm dependency build
-          helm template . > /dev/null
-          echo "QA env helm chart is valid"
+          (
+            cd .ci/tmp-test/.my127ws/helm/qa
+            helm dependency build
+            helm template . > /dev/null
+            echo "QA env helm chart is valid"
+          )
 
       - name: Upload test artifacts
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,18 +50,14 @@ jobs:
       - name: Check generated docker-compose.yml
         if: always()
         run: |
-          if [ -f ".ci/tmp-test/docker-compose.yml" ]; then
+          cd .ci/tmp-test
+          if [ -f "docker-compose.yml" ]; then
             echo "Docker compose file generated successfully"
-            head -50 .ci/tmp-test/docker-compose.yml
           else
             echo "Error: docker-compose.yml was not generated"
             exit 1
           fi
-
-      - name: Validate docker-compose.yml with docker-compose config
-        run: |
-          cd .ci/tmp-test
-          docker-compose config > /dev/null
+          docker compose config > /dev/null
           echo "Docker Compose configuration is valid"
 
       - name: Upload test artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v2
 
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
       - name: Set up PHP 8.4
         uses: "shivammathur/setup-php@v2"
         with:
@@ -59,6 +62,19 @@ jobs:
           fi
           docker compose config > /dev/null
           echo "Docker Compose configuration is valid"
+
+      - name: Test helm charts
+        if: always()
+        run: |
+          cd .ci/tmp-test/.my127ws/helm/preview
+          helm dependency build
+          helm template . > /dev/null
+          echo "Preview env helm chart is valid"
+          
+          cd .ci/tmp-test/.my127ws/helm/qa
+          helm dependency build
+          helm template . > /dev/null
+          echo "QA env helm chart is valid"
 
       - name: Upload test artifacts
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: Test Harness
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test-mode: [static, dynamic]
+    name: Test - ${{ matrix.test-mode }} mode
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run ${{ matrix.test-mode }} test
+        run: |
+          bash .ci/test ${{ matrix.test-mode }}
+
+      - name: Check generated docker-compose.yml
+        if: always()
+        run: |
+          if [ -f ".ci/tmp-test/docker-compose.yml" ]; then
+            echo "Docker compose file generated successfully"
+            head -50 .ci/tmp-test/docker-compose.yml
+          else
+            echo "Error: docker-compose.yml was not generated"
+            exit 1
+          fi
+
+      - name: Validate docker-compose.yml with docker-compose config
+        run: |
+          cd .ci/tmp-test
+          docker-compose config > /dev/null
+          echo "Docker Compose configuration is valid"
+
+      - name: Upload test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-${{ matrix.test-mode }}
+          path: .ci/tmp-test/
+          retention-days: 7
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v2
+
+      - name: Set up PHP 8.4
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: '8.4'
+          tools: composer:v2
+
+      - name: Install required tools
+        run: |
+          apt-get update
+          apt-get install -y rsync
+          
+          # Download the ws binary from the workspace releases
+          curl -L https://github.com/my127/workspace/releases/download/0.4.1/ws -o /tmp/ws
+          chmod +x /tmp/ws
+          sudo mv /tmp/ws /usr/local/bin/ws
+          
+          # Verify installation
+          ws version
 
       - name: Run ${{ matrix.test-mode }} test
         run: |

--- a/_twig/docker-compose.yml/service/bitwarden.yml.twig
+++ b/_twig/docker-compose.yml/service/bitwarden.yml.twig
@@ -1,0 +1,19 @@
+  bitwarden-init:
+    image: alpine:latest
+    environment:
+      BWS_PROJECT_ID: '{{ @('bitwarden.project_id') }}'
+    # Fetch secrets and write to the shared volume
+    command:
+      - sh
+      - -c
+      - |
+        if [ -f /secrets/.env_secrets ]; then
+          echo "Secrets file already exists, skipping fetch."
+          exit 0
+        fi
+        BWS_ACCESS_TOKEN="$$(cat /run/secrets/bws_access_token)" /bitwarden.sh download-all-secrets "$$BWS_PROJECT_ID" /secrets/.env_secrets
+    volumes:
+      - secrets-data:/secrets
+      - .my127ws/harness/scripts/bitwarden.sh:/bitwarden.sh:ro
+    secrets:
+      - bws_access_token

--- a/_twig/docker-compose.yml/service/console.yml.twig
+++ b/_twig/docker-compose.yml/service/console.yml.twig
@@ -17,8 +17,15 @@
       - ./.my127ws/docker/image/console/root/usr/lib/task:/usr/lib/task
       - ./.my127ws:/.my127ws
       - ./.bash_history:/home/build/.bash_history
+{% if @('services.bitwarden.enabled') %}
+      - secrets-data:/secrets:ro
+{% endif %}
 {% else %}
     image: {{ @('services.console.image') }}
+{% if @('services.bitwarden.enabled') %}
+    volumes:
+      - secrets-data:/secrets:ro
+{% endif %}
 {% endif %}
     labels:
       - traefik.enable=false
@@ -32,3 +39,8 @@
       ])), 2, 6) | raw }}
     networks:
       - private
+{% if @('services.bitwarden.enabled') %}
+    depends_on:
+      bitwarden-init:
+        condition: service_completed_successfully
+{% endif %}

--- a/_twig/docker-compose.yml/service/cron.yml.twig
+++ b/_twig/docker-compose.yml/service/cron.yml.twig
@@ -6,8 +6,15 @@
     volumes:
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws/application:/home/build/application
+{% if @('services.bitwarden.enabled') %}
+      - secrets-data:/secrets:ro
+{% endif %}
 {% else %}
     image: {{ @('services.cron.image') }}
+{% if @('services.bitwarden.enabled') %}
+    volumes:
+      - secrets-data:/secrets:ro
+{% endif %}
 {% endif %}
     environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.php-base.environment'),
@@ -22,3 +29,8 @@
     labels:
       # deprecated, a later workspace release will disable by default
       - traefik.enable=false
+{% if @('services.bitwarden.enabled') %}
+    depends_on:
+      bitwarden-init:
+        condition: service_completed_successfully
+{% endif %}

--- a/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
+++ b/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
@@ -8,12 +8,25 @@
     volumes:
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws/application:/home/build/application
+{% if @('services.bitwarden.enabled') %}
+      - secrets-data:/secrets:ro
+{% endif %}
 {% else %}
     image: {{ @('services.jenkins-runner.image') }}
+{% if @('services.bitwarden.enabled') %}
+    volumes:
+      - secrets-data:/secrets:ro
+{% endif %}
 {% endif %}
     depends_on:
-      - console
-      - jenkins
+      console:
+        condition: service_started
+      jenkins:
+        condition: service_started
+{% if @('services.bitwarden.enabled') %}
+      bitwarden-init:
+        condition: service_completed_successfully
+{% endif %}
     environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
         @('services.php-base.environment'),
         @('services.php-base.environment_dynamic'),

--- a/_twig/docker-compose.yml/service/php-fpm.yml.twig
+++ b/_twig/docker-compose.yml/service/php-fpm.yml.twig
@@ -12,8 +12,15 @@
     volumes:
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws:/.my127ws
+{% if @('services.bitwarden.enabled') %}
+      - secrets-data:/secrets:ro
+{% endif %}
 {% else %}
     image: {{ @('services.php-fpm.image') }}
+{% if @('services.bitwarden.enabled') %}
+    volumes:
+      - secrets-data:/secrets:ro
+{% endif %}
 {% endif %}
     labels:
       # deprecated, a later workspace release will disable by default
@@ -32,3 +39,8 @@
 {% for pool in @('php-fpm.pools') %}
       - {{ pool.port }}
 {% endfor %}
+{% if @('services.bitwarden.enabled') %}
+    depends_on:
+      bitwarden-init:
+        condition: service_completed_successfully
+{% endif %}

--- a/_twig/docker-compose.yml/service/queue-worker.yml.twig
+++ b/_twig/docker-compose.yml/service/queue-worker.yml.twig
@@ -3,9 +3,16 @@
     volumes:
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws/application:/home/build/application
+{% if @('services.bitwarden.enabled') %}
+      - secrets-data:/secrets:ro
+{% endif %}
     image: {{ @('workspace.name') ~ '-console:dev' }}
 {% else %}
     image: {{ @('services.console.image') }}
+{% if @('services.bitwarden.enabled') %}
+    volumes:
+      - secrets-data:/secrets:ro
+{% endif %}
 {% endif %}
     pull_policy: never
     environment: {{ to_nice_yaml(docker_compose_escape(deep_merge([
@@ -22,4 +29,9 @@
       # deprecated, a later workspace release will disable by default
       - traefik.enable=false
     depends_on:
-      - console
+      console:
+        condition: service_started
+{% if @('services.bitwarden.enabled') %}
+      bitwarden-init:
+        condition: service_completed_successfully
+{% endif %}

--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -20,7 +20,7 @@ networks:
   shared:
     external: true
     name: my127ws
-{% if syncvolume or @('services.solr.enabled') %}
+{% if syncvolume or @('services.solr.enabled') or @('services.bitwarden.enabled') %}
 volumes:
 {% if syncvolume %}
 {% if bool(@('mutagen')) %}
@@ -36,4 +36,13 @@ volumes:
 {% if @('services.solr.enabled') %}
   solr_data:
 {% endif %}
+{% if @('services.bitwarden.enabled') %}
+  secrets-data:
+{% endif %}
+{% endif %}
+
+{% if @('services.bitwarden.enabled') %}
+secrets:
+  bws_access_token:
+    environment: BWS_ACCESS_TOKEN
 {% endif %}

--- a/docker/image/rabbitmq/root/etc/rabbitmq/definitions.json.twig
+++ b/docker/image/rabbitmq/root/etc/rabbitmq/definitions.json.twig
@@ -1,4 +1,3 @@
-{% spaceless %}
 {% set vhosts = [] %}
 {% for vhost in @('rabbitmq.vhosts') %}
   {% set vhosts = vhosts | merge([{"name": vhost,"metadata": {"description": "","tags": []}, "limits": []}]) %}
@@ -22,7 +21,6 @@
     }]) %}
   {% endfor %}
 {% endfor %}
-{% endspaceless %}
 {
   "bindings": [],
   "exchanges": [],

--- a/docker/image/rabbitmq/root/etc/rabbitmq/definitions.json.twig
+++ b/docker/image/rabbitmq/root/etc/rabbitmq/definitions.json.twig
@@ -1,25 +1,25 @@
 {% set vhosts = [] %}
 {% for vhost in @('rabbitmq.vhosts') %}
-  {% set vhosts = vhosts | merge([{"name": vhost,"metadata": {"description": "","tags": []}, "limits": []}]) %}
+  {%- set vhosts = vhosts | merge([{"name": vhost,"metadata": {"description": "","tags": []}, "limits": []}]) -%}
 {% endfor %}
 {% set users = [] %}
 {% set permissions = [] %}
 {% for user in @('rabbitmq.users') %}
-  {% set users = users | merge([{
+  {%- set users = users | merge([{
     "hashing_algorithm": "rabbit_password_hashing_sha256",
     "name": user.username,
     "password_hash": user.password_hash,
     "tags": user.tags
-  }]) %}
-  {% for permission in user.permissions %}
-    {% set permissions = permissions | merge([{
+  }]) -%}
+  {%- for permission in user.permissions %}
+    {%- set permissions = permissions | merge([{
       "configure": permission.configure,
       "read": permission.read,
       "user": user.username,
       "vhost": permission.vhost,
       "write": permission.write
-    }]) %}
-  {% endfor %}
+    }]) -%}
+  {% endfor -%}
 {% endfor %}
 {
   "bindings": [],

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -1,19 +1,32 @@
 
 command('enable'):
   env:
-    USE_MUTAGEN:          = boolToString(@('host.os') == 'darwin' and bool(@('mutagen')))
-    APP_BUILD:            = @('app.build')
-    APP_MODE:             = @('app.mode')
-    NAMESPACE:            = @('namespace')
-    HAS_ASSETS:           = boolToString(@('aws.bucket') !== null and @('aws.bucket') !== '')
-    COMPOSE_BIN: = @('docker.compose.bin')
-    COMPOSE_PROJECT_NAME: = @('namespace')
+    USE_MUTAGEN:              = boolToString(@('host.os') == 'darwin' and bool(@('mutagen')))
+    APP_BUILD:                = @('app.build')
+    APP_MODE:                 = @('app.mode')
+    NAMESPACE:                = @('namespace')
+    HAS_ASSETS:               = boolToString(@('aws.bucket') !== null and @('aws.bucket') !== '')
+    COMPOSE_BIN:              = @('docker.compose.bin')
+    COMPOSE_PROJECT_NAME:     = @('namespace')
     COMPOSE_DOCKER_CLI_BUILD: = @('docker.buildkit.enabled') ? '1':'0'
     DOCKER_BUILDKIT:          = @('docker.buildkit.enabled') ? '1':'0'
+    BITWARDEN_ENABLED:        = boolToString(@('services.bitwarden.enabled'))
   exec: |
     #!bash(workspace:/)
     set -- all
+    if [ "$BITWARDEN_ENABLED" = yes ] && [ -z "$BWS_ACCESS_TOKEN" ]; then
+      export BWS_ACCESS_TOKEN="$(.my127ws/harness/scripts/bitwarden.sh read-token)"
+    fi
     source .my127ws/harness/scripts/enable.sh
+
+command('refresh secrets'):
+  env:
+    COMPOSE_BIN: = @('docker.compose.bin')
+    COMPOSE_PROJECT_NAME: = @('namespace')
+  exec: |
+    #!bash(workspace:/)
+    BWS_ACCESS_TOKEN= $COMPOSE_BIN run --rm bitwarden-init sh -c 'rm -f /secrets/.env_secrets'
+    ws enable
 
 command('enable console'):
   env:

--- a/harness/config/zzz-overwrite.yml
+++ b/harness/config/zzz-overwrite.yml
@@ -4,6 +4,8 @@
 command('external-images pull [<service>]'):
   env:
     SERVICE: = input.argument('service')
+    BITWARDEN_ENABLED: = boolToString(@('services.bitwarden.enabled'))
+    BWS_PROJECT_ID: =@('bitwarden.project_id')
   exec: |
     #!bash(workspace:/)|@
     CONF_ARGS=()
@@ -14,6 +16,12 @@ command('external-images pull [<service>]'):
     if [ -n "${SERVICE}" ]; then
       CONF_ARGS+=("$SERVICE")
     fi
-    echo '@('docker.registry.password')' | run docker login --username='@('docker.registry.username')' --password-stdin '@('docker.registry.url')'
+    
+    DOCKER_REGISTRY_PASSWORD="@('docker.registry.password')"
+    if [ "$BITWARDEN_ENABLED" = yes ]; then
+      DOCKER_REGISTRY_PASSWORD="$(./.my127ws/harness/scripts/bitwarden.sh download-secret $BWS_PROJECT_ID DOCKER_REGISTRY_PASSWORD)"
+    fi
+    
+    echo $DOCKER_REGISTRY_PASSWORD | run docker login --username='@('docker.registry.username')' --password-stdin '@('docker.registry.url')'
     passthru "ws external-images config $(printf '%q ' "${CONF_ARGS[@]}") | docker-compose --progress=quiet -f - pull"
     run docker logout '@('docker.registry.url')'

--- a/harness/scripts/bitwarden.sh
+++ b/harness/scripts/bitwarden.sh
@@ -1,0 +1,153 @@
+#!/bin/sh
+
+BWS_VERSION="2.0.0"
+
+read_token() {
+  # Check if BWS_ACCESS_TOKEN is set and not empty
+  if [ -z "$BWS_ACCESS_TOKEN" ]; then
+    printf "Please enter Bitwarden Secrets token: " >&2
+    read -r BWS_ACCESS_TOKEN
+
+    # Verify it's not still empty after input
+    if [ -z "$BWS_ACCESS_TOKEN" ]; then
+      echo "Error: BWS_ACCESS_TOKEN cannot be empty. Exiting." >&2
+      exit 1
+    fi
+  fi
+
+  # Return the token value
+  printf "%s" "$BWS_ACCESS_TOKEN"
+}
+
+setup_bws_tool() {
+  if ! command -v bws >/dev/null 2>&1; then
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    ARCH=$(uname -m)
+
+    # Determine the target triple based on OS and architecture
+    if [ "$OS" = "darwin" ]; then
+      # macOS
+      if [ "$ARCH" = "arm64" ]; then
+        BWS_ARCH="aarch64-apple-darwin"
+      else
+        BWS_ARCH="x86_64-apple-darwin"
+      fi
+      # Install dependencies for macOS (if needed)
+      if ! command -v curl >/dev/null 2>&1 || ! command -v unzip >/dev/null 2>&1; then
+        echo "Error: curl and unzip are required. Please install them first." >&2
+        exit 1
+      fi
+    else
+      # Linux
+      if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+        BWS_ARCH="aarch64-unknown-linux-musl"
+      else
+        BWS_ARCH="x86_64-unknown-linux-musl"
+      fi
+      # Install dependencies for Linux (Alpine)
+      if command -v apk >/dev/null 2>&1; then
+        apk add --no-cache curl unzip
+      fi
+    fi
+
+    echo "Downloading bws for ${OS}/${ARCH} (${BWS_ARCH})..." >&2
+    curl -L "https://github.com/bitwarden/sdk-sm/releases/download/bws-v${BWS_VERSION}/bws-${BWS_ARCH}-${BWS_VERSION}.zip" -o /tmp/bws.zip
+    unzip -o /tmp/bws.zip -d /usr/local/bin/
+    chmod +x /usr/local/bin/bws
+    echo "bws installed successfully." >&2
+  fi
+}
+
+download_secret() {
+  local project_id="$1"
+  local secret_name="$2"
+
+  if [ -z "$project_id" ]; then
+    echo "Error: project_id is required" >&2
+    exit 1
+  fi
+  if [ -z "$secret_name" ]; then
+    echo "Error: secret_name is required" >&2
+    exit 1
+  fi
+
+  local token
+  token=$(read_token)
+  setup_bws_tool
+
+  echo "Fetching secret: ${secret_name}..." >&2
+  bws secret list "$project_id" --access-token "$token" -o env | grep "^${secret_name}=" | cut -d'=' -f2- || echo "Secret '${secret_name}' not found in project '${project_id}'." >&2
+}
+
+download_all_secrets() {
+  local project_id="$1"
+  local output_file="$2"
+
+  if [ -z "$project_id" ]; then
+    echo "Error: project_id is required" >&2
+    exit 1
+  fi
+  if [ -z "$output_file" ]; then
+    echo "Error: output_file is required" >&2
+    exit 1
+  fi
+
+  local token
+  token=$(read_token)
+  setup_bws_tool
+
+  echo "Fetching all secrets for project: ${project_id}..." >&2
+  bws secret list "$project_id" --access-token "$token" -o env > "$output_file"
+
+  # Verify that the output file has at least one line with actual content
+  if [ ! -s "$output_file" ] || ! grep -q '[^[:space:]]' "$output_file" 2>/dev/null; then
+    echo "Error: No secrets were written to ${output_file}. The file is empty or contains only whitespace." >&2
+    exit 1
+  fi
+
+  echo "Secrets saved to ${output_file}" >&2
+}
+
+# Main entry point for CLI usage
+main() {
+  local command="$1"
+  shift
+
+  case "$command" in
+    read-token)
+      read_token
+      ;;
+    download-secret)
+      if [ -z "$1" ] || [ -z "$2" ]; then
+        echo "Usage: $0 download-secret <project_id> <secret_name>"
+        echo "Example: $0 download-secret xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx MY_API_KEY"
+        exit 1
+      fi
+      download_secret "$1" "$2"
+      ;;
+    download-all-secrets)
+      if [ -z "$1" ] || [ -z "$2" ]; then
+        echo "Usage: $0 download-all-secrets <project_id> <output_file>"
+        echo "Example: $0 download-all-secrets xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx /secrets/.env_secrets"
+        exit 1
+      fi
+      download_all_secrets "$1" "$2"
+      ;;
+    *)
+      echo "Usage: $0 <command> [arguments]"
+      echo ""
+      echo "Commands:"
+      echo "  read-token                               Prompt for and return the Bitwarden Secrets token"
+      echo "  download-secret <project_id> <secret_name>       Download a specific secret by name"
+      echo "  download-all-secrets <project_id> <output_file>  Download all secrets from a project to a file"
+      echo ""
+      echo "Environment Variables:"
+      echo "  BWS_ACCESS_TOKEN - Bitwarden Secrets Manager access token (will prompt if not set)"
+      exit 1
+      ;;
+  esac
+}
+
+# Execute main with all arguments
+main "$@"
+

--- a/harness/scripts/bitwarden.sh
+++ b/harness/scripts/bitwarden.sh
@@ -58,6 +58,25 @@ setup_bws_tool() {
   fi
 }
 
+fetch_all_secrets_as_env() {
+  local project_id="$1"
+  local token="$2"
+  bws secret list "$project_id" --access-token "$token" -o env
+}
+
+find_secret_line_by_name() {
+  local secret_name="$1"
+  grep "^${secret_name}="
+}
+
+extract_value_after_equals() {
+  cut -d'=' -f2-
+}
+
+remove_surrounding_quotes() {
+  sed 's/^"\(.*\)"$/\1/'
+}
+
 download_secret() {
   local project_id="$1"
   local secret_name="$2"
@@ -71,12 +90,22 @@ download_secret() {
     exit 1
   fi
 
-  local token
-  token=$(read_token)
+  local token="$(read_token)"
   setup_bws_tool
 
   echo "Fetching secret: ${secret_name}..." >&2
-  bws secret list "$project_id" --access-token "$token" -o env | grep "^${secret_name}=" | cut -d'=' -f2- || echo "Secret '${secret_name}' not found in project '${project_id}'." >&2
+
+  local all_secrets="$(fetch_all_secrets_as_env "$project_id" "$token")"
+  local secret_line="$(echo "$all_secrets" | find_secret_line_by_name "$secret_name")"
+
+  if [ -z "$secret_line" ]; then
+    echo "Secret '${secret_name}' not found in project '${project_id}'." >&2
+    return 1
+  fi
+
+  local secret_value="$(echo "$secret_line" | extract_value_after_equals | remove_surrounding_quotes)"
+
+  echo "$secret_value"
 }
 
 download_all_secrets() {
@@ -92,12 +121,11 @@ download_all_secrets() {
     exit 1
   fi
 
-  local token
-  token=$(read_token)
+  local token="$(read_token)"
   setup_bws_tool
 
   echo "Fetching all secrets for project: ${project_id}..." >&2
-  bws secret list "$project_id" --access-token "$token" -o env > "$output_file"
+  fetch_all_secrets_as_env "$project_id" "$token" > "$output_file"
 
   # Verify that the output file has at least one line with actual content
   if [ ! -s "$output_file" ] || ! grep -q '[^[:space:]]' "$output_file" 2>/dev/null; then

--- a/harness/scripts/bitwarden.sh
+++ b/harness/scripts/bitwarden.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 BWS_VERSION="2.0.0"
 
 read_token() {
@@ -20,7 +24,7 @@ read_token() {
 }
 
 setup_bws_tool() {
-  if ! command -v bws >/dev/null 2>&1; then
+  if ! command -v bws >/dev/null; then
     OS=$(uname -s | tr '[:upper:]' '[:lower:]')
     ARCH=$(uname -m)
 
@@ -33,8 +37,8 @@ setup_bws_tool() {
         BWS_ARCH="x86_64-apple-darwin"
       fi
       # Install dependencies for macOS (if needed)
-      if ! command -v curl >/dev/null 2>&1 || ! command -v unzip >/dev/null 2>&1; then
-        echo "Error: curl and unzip are required. Please install them first." >&2
+      if ! command -v curl >/dev/null || ! command -v unzip >/dev/null; then
+        echo "Error: curl and unzip are required. Please install them first."
         exit 1
       fi
     else
@@ -45,16 +49,16 @@ setup_bws_tool() {
         BWS_ARCH="x86_64-unknown-linux-musl"
       fi
       # Install dependencies for Linux (Alpine)
-      if command -v apk >/dev/null 2>&1; then
+      if command -v apk >/dev/null; then
         apk add --no-cache curl unzip
       fi
     fi
 
-    echo "Downloading bws for ${OS}/${ARCH} (${BWS_ARCH})..." >&2
+    echo "Downloading bws for ${OS}/${ARCH} (${BWS_ARCH})..."
     curl -L "https://github.com/bitwarden/sdk-sm/releases/download/bws-v${BWS_VERSION}/bws-${BWS_ARCH}-${BWS_VERSION}.zip" -o /tmp/bws.zip
     unzip -o /tmp/bws.zip -d /usr/local/bin/
     chmod +x /usr/local/bin/bws
-    echo "bws installed successfully." >&2
+    echo "bws installed successfully."
   fi
 }
 
@@ -91,12 +95,12 @@ download_secret() {
   fi
 
   local token="$(read_token)"
-  setup_bws_tool
+  setup_bws_tool >&2
 
   echo "Fetching secret: ${secret_name}..." >&2
 
   local all_secrets="$(fetch_all_secrets_as_env "$project_id" "$token")"
-  local secret_line="$(echo "$all_secrets" | find_secret_line_by_name "$secret_name")"
+  local secret_line=$(echo "$all_secrets" | find_secret_line_by_name "$secret_name")
 
   if [ -z "$secret_line" ]; then
     echo "Secret '${secret_name}' not found in project '${project_id}'." >&2
@@ -122,7 +126,7 @@ download_all_secrets() {
   fi
 
   local token="$(read_token)"
-  setup_bws_tool
+  setup_bws_tool >&2
 
   echo "Fetching all secrets for project: ${project_id}..." >&2
   fetch_all_secrets_as_env "$project_id" "$token" > "$output_file"

--- a/harnesses.json
+++ b/harnesses.json
@@ -72,8 +72,8 @@
     },
     "v1.10.0": {
       "type": "tar.gz",
-      "url": "https://github.com/teufelaudio/harness-spryker/archive/refs/heads/task/WEBDEV-11030-bitwarden-secret-manager.tar.gz",
-      "date": "2026-03-17"
+      "url": "https://github.com/teufelaudio/harness-spryker/archive/1.10.0.tar.gz",
+      "date": "2026-03-25"
     }
   }
 }

--- a/harnesses.json
+++ b/harnesses.json
@@ -69,6 +69,11 @@
       "type": "tar.gz",
       "url": "https://github.com/teufelaudio/harness-spryker/archive/1.9.0.tar.gz",
       "date": "2025-11-18"
+    },
+    "v1.10.0": {
+      "type": "tar.gz",
+      "url": "https://github.com/teufelaudio/harness-spryker/archive/refs/heads/task/WEBDEV-11030-bitwarden-secret-manager.tar.gz",
+      "date": "2026-03-17"
     }
   }
 }


### PR DESCRIPTION
### Goal
Support storing project secrets in bitwarden

### Changes

- Add bitwarden-init service to download and store secrets using bws (bitwarden cli) into an internal volume (secrets-data)
- Update other services that needs access of secrets (console, php-fpm, etc) to
  - attach secrets volume
  - add dependency on bitwarden-init service (so that it does not start before this init service completes successfully)
- Add docker-compose secret to store bitwarden token
- Add bitwarden.sh script to download bws tool and download secrets
- Update "ws enable" command to ask for bitwarden token via user input (by default it would only download secrets once)
- Add "ws refresh secrets" command to download secrets again

_Note:_ this service is disabled by default. To enable it, you would need to set `attribute('services.bitwarden.enabled'): true` and provide a bitwarden project ID using `attribute('bitwarden.project_id'): <Project ID>`

