### PR TITLE
Make bitwarden server url configurable

### DIFF
--- a/.ci/sample-dynamic/workspace.yml
+++ b/.ci/sample-dynamic/workspace.yml
@@ -13,3 +13,4 @@ attribute('docker.port_forward.enabled'): false
 
 attribute('services.bitwarden.enabled'): true
 attribute('bitwarden.project_id'): 1
+attribute('bitwarden.server_url'): https://bitwarden.example.com

--- a/.ci/sample-static/workspace.yml
+++ b/.ci/sample-static/workspace.yml
@@ -13,3 +13,4 @@ attribute('aws.secret_access_key'): null
 
 attribute('services.bitwarden.enabled'): true
 attribute('bitwarden.project_id'): 1
+attribute('bitwarden.server_url'): https://bitwarden.example.com

--- a/_twig/docker-compose.yml/service/bitwarden.yml.twig
+++ b/_twig/docker-compose.yml/service/bitwarden.yml.twig
@@ -2,6 +2,7 @@
     image: alpine:latest
     environment:
       BWS_PROJECT_ID: '{{ @('bitwarden.project_id') }}'
+      BWS_SERVER_URL: '{{ @('bitwarden.server_url') }}'
     # Fetch secrets and write to the shared volume
     command:
       - sh
@@ -11,7 +12,7 @@
           echo "Secrets file already exists, skipping fetch."
           exit 0
         fi
-        BWS_ACCESS_TOKEN="$$(cat /run/secrets/bws_access_token)" /bitwarden.sh download-all-secrets "$$BWS_PROJECT_ID" /secrets/.env_secrets
+        BWS_ACCESS_TOKEN="$$(cat /run/secrets/bws_access_token)" /bitwarden.sh download-all-secrets "$$BWS_SERVER_URL" "$$BWS_PROJECT_ID" /secrets/.env_secrets
     volumes:
       - secrets-data:/secrets
       - .my127ws/harness/scripts/bitwarden.sh:/bitwarden.sh:ro

--- a/harness/attributes/docker-base.yml
+++ b/harness/attributes/docker-base.yml
@@ -53,9 +53,6 @@ attributes:
         DB_ADMIN_USER: root
         HAS_ELASTICSEARCH: "= @('services.elasticsearch.enabled') ? 'true' : 'false'"
         HAS_VARNISH: "= @('services.varnish.enabled') ? 'true' : 'false'"
-      environment_secrets:
-        DB_ADMIN_PASS: = @('database.root_pass')
-        ADMIN_DEFAULT_PASSWORD: admin123
       resources:
         memory: "2048Mi"
         init_memory: "1024Mi"

--- a/harness/config/pipeline.yml
+++ b/harness/config/pipeline.yml
@@ -47,7 +47,7 @@ command('app publish'):
     DOCKER_CLIENT_TIMEOUT: 180
   exec: |
     #!bash(workspace:/)|@
-    echo '@('docker.registry.password')' | run docker login --username='@('docker.registry.username')' --password-stdin '@('docker.registry.url')'
+    ws docker login
     passthru $COMPOSE_BIN push @('pipeline.publish.services')
     run docker logout '@('docker.registry.url')'
 

--- a/harness/config/teufel-commands.yml
+++ b/harness/config/teufel-commands.yml
@@ -143,9 +143,16 @@ command('run playwright-ci'):
 command('docker login'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
+    BITWARDEN_ENABLED: = boolToString(@('services.bitwarden.enabled'))
+    BWS_PROJECT_ID: =@('bitwarden.project_id')
+    BWS_SERVER_URL: =@('bitwarden.server_url')
   exec: |
     #!bash(workspace:/)|@
-    echo '@('docker.registry.password')' | run docker login --username='@('docker.registry.username')' --password-stdin '@('docker.registry.url')'
+    DOCKER_REGISTRY_PASSWORD="@('docker.registry.password')"
+    if [ "$BITWARDEN_ENABLED" = yes ]; then
+      DOCKER_REGISTRY_PASSWORD="$(./.my127ws/harness/scripts/bitwarden.sh download-secret $BWS_SERVER_URL $BWS_PROJECT_ID DOCKER_REGISTRY_PASSWORD)"
+    fi
+    echo $DOCKER_REGISTRY_PASSWORD | run docker login --username='@('docker.registry.username')' --password-stdin '@('docker.registry.url')'
 
 command('help'):
   exec: |

--- a/harness/config/zzz-overwrite.yml
+++ b/harness/config/zzz-overwrite.yml
@@ -4,9 +4,6 @@
 command('external-images pull [<service>]'):
   env:
     SERVICE: = input.argument('service')
-    BITWARDEN_ENABLED: = boolToString(@('services.bitwarden.enabled'))
-    BWS_PROJECT_ID: =@('bitwarden.project_id')
-    BWS_SERVER_URL: =@('bitwarden.server_url')
   exec: |
     #!bash(workspace:/)|@
     CONF_ARGS=()
@@ -18,11 +15,6 @@ command('external-images pull [<service>]'):
       CONF_ARGS+=("$SERVICE")
     fi
     
-    DOCKER_REGISTRY_PASSWORD="@('docker.registry.password')"
-    if [ "$BITWARDEN_ENABLED" = yes ]; then
-      DOCKER_REGISTRY_PASSWORD="$(./.my127ws/harness/scripts/bitwarden.sh download-secret $BWS_SERVER_URL $BWS_PROJECT_ID DOCKER_REGISTRY_PASSWORD)"
-    fi
-    
-    echo $DOCKER_REGISTRY_PASSWORD | run docker login --username='@('docker.registry.username')' --password-stdin '@('docker.registry.url')'
+    ws docker login
     passthru "ws external-images config $(printf '%q ' "${CONF_ARGS[@]}") | docker-compose --progress=quiet -f - pull"
     run docker logout '@('docker.registry.url')'

--- a/harness/config/zzz-overwrite.yml
+++ b/harness/config/zzz-overwrite.yml
@@ -6,6 +6,7 @@ command('external-images pull [<service>]'):
     SERVICE: = input.argument('service')
     BITWARDEN_ENABLED: = boolToString(@('services.bitwarden.enabled'))
     BWS_PROJECT_ID: =@('bitwarden.project_id')
+    BWS_SERVER_URL: =@('bitwarden.server_url')
   exec: |
     #!bash(workspace:/)|@
     CONF_ARGS=()
@@ -19,7 +20,7 @@ command('external-images pull [<service>]'):
     
     DOCKER_REGISTRY_PASSWORD="@('docker.registry.password')"
     if [ "$BITWARDEN_ENABLED" = yes ]; then
-      DOCKER_REGISTRY_PASSWORD="$(./.my127ws/harness/scripts/bitwarden.sh download-secret $BWS_PROJECT_ID DOCKER_REGISTRY_PASSWORD)"
+      DOCKER_REGISTRY_PASSWORD="$(./.my127ws/harness/scripts/bitwarden.sh download-secret $BWS_SERVER_URL $BWS_PROJECT_ID DOCKER_REGISTRY_PASSWORD)"
     fi
     
     echo $DOCKER_REGISTRY_PASSWORD | run docker login --username='@('docker.registry.username')' --password-stdin '@('docker.registry.url')'

--- a/harness/scripts/bitwarden.sh
+++ b/harness/scripts/bitwarden.sh
@@ -81,9 +81,10 @@ setup_bws_tool() {
 }
 
 fetch_all_secrets_as_env() {
-  local project_id="$1"
-  local token="$2"
-  bws secret list "$project_id" --access-token "$token" -o env
+  local server_url="$1"
+  local project_id="$2"
+  local token="$3"
+  bws secret list "$project_id" --server-url "$server_url" --access-token "$token" -o env
 }
 
 find_secret_line_by_name() {
@@ -100,8 +101,9 @@ remove_surrounding_quotes() {
 }
 
 download_secret() {
-  local project_id="$1"
-  local secret_name="$2"
+  local server_url="$1"
+  local project_id="$2"
+  local secret_name="$3"
 
   if [ -z "$project_id" ]; then
     echo "Error: project_id is required" >&2
@@ -117,7 +119,7 @@ download_secret() {
 
   echo "Fetching secret: ${secret_name}..." >&2
 
-  local all_secrets="$(fetch_all_secrets_as_env "$project_id" "$token")"
+  local all_secrets="$(fetch_all_secrets_as_env "$server_url" "$project_id" "$token")"
   local secret_line=$(echo "$all_secrets" | find_secret_line_by_name "$secret_name")
 
   if [ -z "$secret_line" ]; then
@@ -131,8 +133,9 @@ download_secret() {
 }
 
 download_all_secrets() {
-  local project_id="$1"
-  local output_file="$2"
+  local server_url="$1"
+  local project_id="$2"
+  local output_file="$3"
 
   if [ -z "$project_id" ]; then
     echo "Error: project_id is required" >&2
@@ -147,7 +150,7 @@ download_all_secrets() {
   setup_bws_tool >&2
 
   echo "Fetching all secrets for project: ${project_id}..." >&2
-  fetch_all_secrets_as_env "$project_id" "$token" > "$output_file"
+  fetch_all_secrets_as_env "$server_url" "$project_id" "$token" > "$output_file"
 
   # Verify that the output file has at least one line with actual content
   if [ ! -s "$output_file" ] || ! grep -q '[^[:space:]]' "$output_file" 2>/dev/null; then
@@ -168,28 +171,28 @@ main() {
       read_token
       ;;
     download-secret)
-      if [ -z "$1" ] || [ -z "$2" ]; then
-        echo "Usage: $0 download-secret <project_id> <secret_name>"
-        echo "Example: $0 download-secret xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx MY_API_KEY"
+      if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
+        echo "Usage: $0 download-secret <server_url> <project_id> <secret_name>"
+        echo "Example: $0 download-secret https://vault.teufelhome.com xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx MY_API_KEY"
         exit 1
       fi
-      download_secret "$1" "$2"
+      download_secret "$1" "$2" "$3"
       ;;
     download-all-secrets)
-      if [ -z "$1" ] || [ -z "$2" ]; then
-        echo "Usage: $0 download-all-secrets <project_id> <output_file>"
-        echo "Example: $0 download-all-secrets xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx /secrets/.env_secrets"
+      if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
+        echo "Usage: $0 download-all-secrets <server_url> <project_id> <output_file>"
+        echo "Example: $0 download-all-secrets https://vault.teufelhome.com xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx /secrets/.env_secrets"
         exit 1
       fi
-      download_all_secrets "$1" "$2"
+      download_all_secrets "$1" "$2" "$3"
       ;;
     *)
       echo "Usage: $0 <command> [arguments]"
       echo ""
       echo "Commands:"
       echo "  read-token                               Prompt for and return the Bitwarden Secrets token"
-      echo "  download-secret <project_id> <secret_name>       Download a specific secret by name"
-      echo "  download-all-secrets <project_id> <output_file>  Download all secrets from a project to a file"
+      echo "  download-secret <server_url> <project_id> <secret_name>       Download a specific secret by name"
+      echo "  download-all-secrets <server_url> <project_id> <output_file>  Download all secrets from a project to a file"
       echo ""
       echo "Environment Variables:"
       echo "  BWS_ACCESS_TOKEN - Bitwarden Secrets Manager access token (will prompt if not set)"

--- a/harnesses.json
+++ b/harnesses.json
@@ -79,6 +79,11 @@
       "type": "tar.gz",
       "url": "https://github.com/teufelaudio/harness-spryker/archive/1.10.1.tar.gz",
       "date": "2026-03-31"
+    },
+    "v1.10.2": {
+      "type": "tar.gz",
+      "url": "https://github.com/teufelaudio/harness-spryker/archive/refs/heads/task/WEBDEV-11030-configure-bitwarden-url.tar.gz",
+      "date": "2026-04-14"
     }
   }
 }

--- a/harnesses.json
+++ b/harnesses.json
@@ -82,8 +82,8 @@
     },
     "v1.10.2": {
       "type": "tar.gz",
-      "url": "https://github.com/teufelaudio/harness-spryker/archive/refs/heads/task/WEBDEV-11030-configure-bitwarden-url.tar.gz",
-      "date": "2026-04-14"
+      "url": "https://github.com/teufelaudio/harness-spryker/archive/1.10.2.tar.gz",
+      "date": "2026-04-16"
     }
   }
 }


### PR DESCRIPTION
- Make it possible to pass bitwarden server_url via attribute
- Remove unnecessary env vars from base harness file
- Update "ws app publish" and "ws external-images pull" commands to use "ws docker login" command internally, as this command contains logic to fetch docker registry password from bitwarden when enabled