### PR TITLE
WEBDEV-11309 Prevent nginx from falling back to PHP for certain static assets

### DIFF
--- a/docker/image/nginx/root/etc/nginx/conf.d/yves.conf.template.twig
+++ b/docker/image/nginx/root/etc/nginx/conf.d/yves.conf.template.twig
@@ -25,13 +25,20 @@ server {
         #more_clear_headers 'X-Powered-By' 'X-Store' 'X-Locale' 'X-Env' 'Server';
     }
 
-    location ~ \.(jpg|gif|png|css|js|html|xml|ico|txt|csv|map)$ {
+    location ~ \.(jpg|gif|png|ico|txt|csv|map)$ {
+        access_log off;
+        expires 30d;
+        add_header Pragma public;
+        add_header Cache-Control "public";
+        try_files $uri =404;
+    }
+
+    location ~ \.(css|js|html|xml)$ {
         access_log off;
         expires 30d;
         add_header Pragma public;
         add_header Cache-Control "public";
         try_files $uri /index.php?$args;
-        #more_clear_headers 'X-Powered-By' 'X-Store' 'X-Locale' 'X-Env' 'Server';
     }
 
     # PHP application


### PR DESCRIPTION
During a recent debugging session, I noticed I was getting 3 PHP requests for a single page:

- The page I was on
- /yves_default.critical.css.map
- an error page, because the page above does not exist
 
The css.map files must be served by nginx, not php.

In a perfect world we would always create the map files, but if they don't exist they shouldn't cause these extra requests.

In our nginx config, for static assets we fallback to PHP, if the asset is not there

```
        try_files $uri /index.php?$args;
```

I thought about removing the fallback, because we should not need to dynamically generate images, etc, but to be safe I split into 2 blocks: a block with fallback, and a block without.